### PR TITLE
Reattempt failed flash operations

### DIFF
--- a/libraries/InternalFileSytem/src/flash/flash_nrf5x.c
+++ b/libraries/InternalFileSytem/src/flash/flash_nrf5x.c
@@ -28,6 +28,8 @@
 #include "nrf_soc.h"
 #include "delay.h"
 #include "rtos.h"
+#include "assert.h"
+
 
 #ifdef NRF52840_XXAA
   #define BOOTLOADER_ADDR        0xF4000
@@ -43,46 +45,56 @@ extern uint32_t __flash_arduino_start[];
 // MACRO TYPEDEF CONSTANT ENUM DECLARATION
 //--------------------------------------------------------------------+
 static SemaphoreHandle_t _sem = NULL;
-static bool _flash_op_failed = false;
+static uint32_t _flash_op_result = NRF_EVT_FLASH_OPERATION_SUCCESS;
 
 void flash_nrf5x_event_cb (uint32_t event)
 {
   if ( _sem ) {
     // Record the result, for consumption by fal_erase or fal_program
     // Used to reattempt failed operations
-    _flash_op_failed = (event == NRF_EVT_FLASH_OPERATION_ERROR);
+    _flash_op_result = event;
 
     // Signal to fal_erase or fal_program that our async flash op is now complete
     xSemaphoreGive(_sem);
   } 
 }
 
-// How many retry attempts when performing flash write operations 
+// How many retry attempts when performing flash operations 
 #define MAX_RETRY 20
 
-// Check whether a flash operation was successful, or should be repeated
-static bool retry_flash_op (uint32_t op_result, bool sd_enabled) {
-  // If busy
-  if (op_result == NRF_ERROR_BUSY) {
-    delay(1);
-    return true; // Retry
-  }
+// When soft device is enabled, flash ops are async
+// Eventual success is reported via callback, which we await
+static uint32_t wait_for_async_flash_op_completion(uint32_t initial_result) 
+{
+  // If initial result not NRF_SUCCESS, no need to await callback
+  // We will pass the initial result (failure) straight through
+  int32_t result = initial_result;
 
-  // Unspecified error
-  if (op_result != NRF_SUCCESS)
-    return true; // Retry
+  // Operation was queued successfully
+  if (initial_result == NRF_SUCCESS) {
 
-  // If the soft device is enabled, flash operations run async
-  // The callback (flash_nrf5x_event_cb) will give semaphore when the flash operation is complete
-  // The callback also checks for NRF_EVT_FLASH_OPERATION_ERROR, which is not available to us otherwise
-  if (sd_enabled) {
+    // Wait for result via callback 
     xSemaphoreTake(_sem, portMAX_DELAY);
-    if (_flash_op_failed) 
-      return true; // Retry
-  }
+    
+    // If completed successfully
+    if (_flash_op_result == NRF_EVT_FLASH_OPERATION_SUCCESS) { 
+      result = NRF_SUCCESS; 
+    }
 
-  // Success
-  return false;
+    // If general failure.
+    // The comment on NRF_EVT_FLASH_OPERATION_ERROR describes it as a timeout,
+    // so we're using a similar error when translating from NRF_SOC_EVTS type to the global NRF52 error defines
+    else if (_flash_op_result == NRF_EVT_FLASH_OPERATION_ERROR) { 
+      result = NRF_ERROR_TIMEOUT; 
+    }
+    
+    // If this assert triggers, we need to implement a new NRF_SOC_EVTS value
+    else { 
+      assert(false); 
+    }
+  }
+  
+  return result;
 }
 
 // Flash Abstraction Layer
@@ -139,8 +151,7 @@ bool flash_nrf5x_erase(uint32_t addr)
 static bool fal_erase (uint32_t addr)
 {
   // Init semaphore for first call
-  if ( _sem == NULL )
-  {
+  if ( _sem == NULL ) {
     _sem = xSemaphoreCreateBinary();
     VERIFY(_sem);
   }
@@ -150,19 +161,30 @@ static bool fal_erase (uint32_t addr)
   uint8_t sd_en = 0;
   (void) sd_softdevice_is_enabled(&sd_en);
 
-  // Make multiple attempts to erase
-  uint8_t attempt = 0;
-  while (retry_flash_op(sd_flash_page_erase(addr / FLASH_NRF52_PAGE_SIZE), sd_en)) {
-    if (++attempt > MAX_RETRY)
-      return false; // Failure
+  // Erase the page
+  // Multiple attempts if needed
+  uint32_t err;
+  for (uint8_t attempt = 0; attempt < MAX_RETRY; ++attempt) {
+    err = sd_flash_page_erase(addr / FLASH_NRF52_PAGE_SIZE);
+
+    if (sd_en) { 
+      err = wait_for_async_flash_op_completion(err); // Only async if soft device enabled
+    }
+    if (err == NRF_SUCCESS) {
+      break;
+    }
+    if (err == NRF_ERROR_BUSY) {
+      delay(1);
+    }
   }
-    return true; // Success
+  VERIFY_STATUS(err, false); // Return false if all retries fail
+
+  return true; // Successfully erased
 }
 
 static uint32_t fal_program (uint32_t dst, void const * src, uint32_t len)
 {
-  // Check if soft device is enabled
-  // If yes, flash operations are async, so we need to wait for the callback to give the semaphore
+  // wait for async event if SD is enabled
   uint8_t sd_en = 0;
   (void) sd_softdevice_is_enabled(&sd_en);
 
@@ -172,26 +194,57 @@ static uint32_t fal_program (uint32_t dst, void const * src, uint32_t len)
   // https://devzone.nordicsemi.com/f/nordic-q-a/40088/sd_flash_write-cause-nrf_fault_id_sd_assert
   // Workaround: write half page at a time.
 #if NRF52832_XXAA
-  uint8_t attempt = 0;
-  while (retry_flash_op(sd_flash_write((uint32_t*) dst, (uint32_t const *) src, len/4), sd_en)) {
-    if (++attempt > MAX_RETRY)
-      return 0; // Failure
+  // Write the page
+  // Multiple attempts, if needed
+  for (uint8_t attempt = 0; attempt < MAX_RETRY; ++attempt) {
+    err = sd_flash_write((uint32_t*) dst, (uint32_t const *) src, len/4);
+
+    if (sd_en) {
+      err = wait_for_async_flash_op_completion(err); // Only async if soft device enabled
+    }
+    if (err == NRF_SUCCESS) { 
+      break; 
+    }
+    if (err == NRF_ERROR_BUSY) {
+      delay(1);
+    }
   }
+  VERIFY_STATUS(err, 0); // Return 0 if all retries fail
+
 #else
+  // Write first part of page
+  // Multiple attempts, if needed
+  for (uint8_t attempt = 0; attempt < MAX_RETRY; ++attempt) {
+    err = sd_flash_write((uint32_t*) dst, (uint32_t const *) src, len/8);
 
-  // First part of block
-  uint8_t attempt = 0;
-  while (retry_flash_op(sd_flash_write((uint32_t*) dst, (uint32_t const *) src, len/8), sd_en)) {
-    if (++attempt > MAX_RETRY)
-      return 0; // Failure
+    if (sd_en) { 
+      err = wait_for_async_flash_op_completion(err); // Only async if soft device enabled
+    }
+    if (err == NRF_SUCCESS) {
+      break;
+    }
+    if (err == NRF_ERROR_BUSY) {
+      delay(1);
+    }
   }
+  VERIFY_STATUS(err, 0); // Return 0 if all retries fail
 
-  // Second part of block
-  attempt = 0;
-  while (retry_flash_op(sd_flash_write((uint32_t*) (dst+ len/2), (uint32_t const *) (src + len/2), len/8), sd_en)) {
-    if (++attempt > MAX_RETRY)
-      return 0; // Failure
+  // Write second part of page
+  // Multiple attempts, if needed
+  for (uint8_t attempt = 0; attempt < MAX_RETRY; ++attempt) {
+    err = sd_flash_write((uint32_t*) (dst+ len/2), (uint32_t const *) (src + len/2), len/8);
+
+    if (sd_en) {
+      err = wait_for_async_flash_op_completion(err); // Only async if soft device enabled
+    }
+    if (err == NRF_SUCCESS) {
+      break;
+    }
+    if (err == NRF_ERROR_BUSY) {
+      delay(1);
+    }
   }
+  VERIFY_STATUS(err, 0); // Return 0 if all retries fail
 #endif
 
   return len;


### PR DESCRIPTION
In collaboration with @esev 

Submitted for your consideration. Seems to be working, *but definitely needs careful review.*

(Hopefully) resolves the issues with NRF52 flash corruption which are occasionally caused when a connected BLE device moves out of range.
 
Flash operations are asynchronous when softdevice is enabled. If a BLE connection terminates non-gracefully (`BLE_HCI_CONNECTION_TIMEOUT` etc), it will cause an in-progress write/erase operation to fail.

___

**Currently:** failure of an async flash operation is not detected. No attempt to repeat is made if the operation failed.

<details>
<summary>Log (old)</summary> 

```
INFO  | 20:29:31 2159141 [Router] Save /prefs/db.proto
lfs debug:617: Bad block at 126
lfs debug:617: Bad block at 180
INFO  | 20:29:36 2159146 [Router] BLE Disconnected, reason = 0x8
DEBUG | 20:29:36 2159146 [Router] PhoneAPI::close()
lfs debug:640: Relocating 126 160 to 181 160
```
</details>

___

**This PR:** detects failed flash operations using info available in the flash event callback, and makes several additional attempts to repeat a failed operation (before eventually giving up, if necessary).

<details>
<summary>Log</summary>

```
DEBUG | 16:17:19 43 [Button] Opening /prefs/config.proto, fullAtomic=1
INFO  | 16:17:19 43 [Button] Save /prefs/config.proto
DEBUG | 16:17:20 44 [Button] Opening /prefs/module.proto, fullAtomic=1
INFO  | 16:17:20 44 [Button] Save /prefs/module.proto
DEBUG | 16:17:20 44 [Button] Opening /prefs/channels.proto, fullAtomic=1
INFO  | 16:17:20 44 [Button] Save /prefs/channels.proto
INFO  | 16:17:25 49 [Button] BLE Disconnected, reason = 0x8
DEBUG | 16:17:25 49 [Button] PhoneAPI::close()
DEBUG | 16:17:25 49 [Button] Opening /prefs/db.proto, fullAtomic=0
INFO  | 16:17:25 49 [Button] Save /prefs/db.proto
DEBUG | 16:17:25 49 [Button] State: ON
DEBUG | 16:17:25 49 [Power] Battery: usbPower=0, isCharging=0, batMv=4172, batPct=98
INFO  | 16:17:25 49 [DeviceTelemetry] Send: air_util_tx=0.002611, channel_utilization=0.156667, battery_level=98, voltage=4.172000, uptime=49
```
</details>

<details>
<summary>Log (verbose)</summary>

Note: Write 1 and Write 2 are a result of a pre-existing workaround:
> // Somehow S140 v6.1.1 assert an error when writing a whole page
> // https://devzone.nordicsemi.com/f/nordic-q-a/40088/sd_flash_write-cause-nrf_fault_id_sd_assert
> // Workaround: write half page at a time.

```
DEBUG | 09:11:25 503 [Button] Opening /prefs/config.proto, fullAtomic=1
INFO  | 09:11:25 503 [Button] Save /prefs/config.proto
[SOC   ] NRF_EVT_FLASH_OPERATION_ERROR#
[IFLASH] Erase: retry#
[SOC   ] NRF_EVT_FLASH_OPERATION_ERROR#
[IFLASH] Erase: retry#
[SOC   ] NRF_EVT_FLASH_OPERATION_ERROR#
[IFLASH] Erase: retry#
INFO  | 09:11:27 505 [Button] BLE Disconnected, reason = 0x8
DEBUG | 09:11:27 505 [Button] PhoneAPI::close()
[SOC   ] NRF_EVT_FLASH_OPERATION_SUCCESS#
[IFLASH] Erase: success#
[SOC   ] NRF_EVT_FLASH_OPERATION_SUCCESS#
[IFLASH] Write 1: success#
[SOC   ] NRF_EVT_FLASH_OPERATION_SUCCESS#
[IFLASH] Write 2: success#
DEBUG | 09:11:27 505 [Button] Opening /prefs/module.proto, fullAtomic=1
INFO  | 09:11:27 505 [Button] Save /prefs/module.proto
INFO  | 09:11:27 505 [Button] BLE Connected to TH-Phone
[SOC   ] NRF_EVT_FLASH_OPERATION_SUCCESS#
[IFLASH] Erase: success#
[SOC   ] NRF_EVT_FLASH_OPERATION_SUCCESS#
[IFLASH] Write 1: success#
[SOC   ] NRF_EVT_FLASH_OPERATION_SUCCESS#
[IFLASH] Write 2: success#
DEBUG | 09:11:27 506 [Button] Opening /prefs/channels.proto, fullAtomic=1
INFO  | 09:11:27 506 [Button] Save /prefs/channels.proto
[SOC   ] NRF_EVT_FLASH_OPERATION_SUCCESS#
[IFLASH] Erase: success#
[SOC   ] NRF_EVT_FLASH_OPERATION_SUCCESS#
[IFLASH] Write 1: success#
[SOC   ] NRF_EVT_FLASH_OPERATION_SUCCESS#
[IFLASH] Write 2: success#
[GAP   ] Conn Interval= 7.50 ms, Latency = 0, Supervisor Timeout = 5000 ms#
[SOC   ] NRF_EVT_FLASH_OPERATION_SUCCESS#
[IFLASH] Erase: success#
[SOC   ] NRF_EVT_FLASH_OPERATION_SUCCESS#
[IFLASH] Write 1: success#
[SOC   ] NRF_EVT_FLASH_OPERATION_SUCCESS#
[IFLASH] Write 2: success#
[BOND  ] Loaded keys from file /adafruit/bond_prph/C921C7F59F80#
DEBUG | 09:11:28 506 [Button] Opening /prefs/db.proto, fullAtomic=0
INFO  | 09:11:28 506 [Button] Save /prefs/db.proto
[BOND  ] Loaded CCCD from file /adafruit/bond_prph/C921C7F59F80 ( offset = 91, len = 32 bytes )#
INFO  | 09:11:28 506 [Button] BLE connection secured
[SOC   ] NRF_EVT_FLASH_OPERATION_SUCCESS#
[IFLASH] Erase: success#
[SOC   ] NRF_EVT_FLASH_OPERATION_SUCCESS#
[IFLASH] Write 1: success#
[SOC   ] NRF_EVT_FLASH_OPERATION_SUCCESS#
[IFLASH] Write 2: success#
[SOC   ] NRF_EVT_FLASH_OPERATION_SUCCESS#
[IFLASH] Erase: success#
[SOC   ] NRF_EVT_FLASH_OPERATION_SUCCESS#
[IFLASH] Write 1: success#
[SOC   ] NRF_EVT_FLASH_OPERATION_SUCCESS#
[IFLASH] Write 2: success#
DEBUG | 09:11:29 507 [Button] State: ON
bool BLEAdvertising::_start(uint16_t, uint16_t): 379: verify failed, error = NRF_ERROR_CONN_COUNT#
[GAP   ] ATT MTU is changed to 247#
DEBUG | 09:11:29 507 [Power] Battery: usbPower=0, isCharging=0, batMv=4198, batPct=100
[GAP   ] Conn Interval= 48.75 ms, Latency = 0, Supervisor Timeout = 5000 ms#
INFO  | 09:11:30 508 toRadioWriteCb data 0x2001f66a, len 2
DEBUG | 09:11:30 508 New ToRadio packet
INFO  | 09:11:30 508 Client wants config, nonce=65
DEBUG | 09:11:30 508 Got 4 files in manifest
INFO  | 09:11:30 508 Start API client config
[GATTS ] attr's cccd = 0x0001#
INFO  | 09:11:30 508 CCCD Updated: 1
INFO  | 09:11:30 508 Notify/Indicate enabled
[BOND  ] CCCD matches file /adafruit/bond_prph/C921C7F59F80 contents, no need to write#
DEBUG | 09:11:30 508 FromRadio=STATE_SEND_MY_INFO
INFO  | 09:11:30 508 getFromRadio=STATE_SEND_UIDATA
DEBUG | 09:11:30 508 Send My NodeInfo
DEBUG | 09:11:30 508 Send device metadata
DEBUG | 09:11:31 509 Send channels 8
DEBUG | 09:11:31 509 Send config: device
```
</details>