### PR TITLE
nrf52(fs): add File() default constructor bound to InternalFS

### DIFF
--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp
@@ -24,6 +24,7 @@
 
 #include <Arduino.h>
 #include "Adafruit_LittleFS.h"
+#include "InternalFileSystem.h"
 #include "littlefs/lfs.h"
 
 //--------------------------------------------------------------------+
@@ -416,5 +417,12 @@ void File::rewindDirectory (void)
     lfs_dir_rewind(_fs->_getFS(), _dir);
   }
   _fs->_unlockFS();
+}
+
+// Default constructor — binds to the global InternalFS instance.
+// Allows File to be declared without an explicit filesystem argument,
+// matching the API of ESP32/RP2040/Portduino File objects.
+File::File() : File(InternalFS)
+{
 }
 

--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.h
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.h
@@ -43,6 +43,7 @@ class File : public Stream
   public:
     File (Adafruit_LittleFS &fs);
     File (char const *filename, uint8_t mode, Adafruit_LittleFS &fs);
+    File (); // default-constructs against InternalFS; defined in Adafruit_LittleFS_File.cpp
 
   public:
 


### PR DESCRIPTION
Adds a no-argument File constructor that delegates to File(InternalFS). This matches the default-constructible File API available on ESP32, RP2040, and Portduino, allowing shared firmware code (e.g. xmodem.h) to declare File objects without an explicit filesystem argument.

InternalFS is the global singleton defined in InternalFileSystem.cpp; the constructor is implemented in the .cpp to avoid a circular include between Adafruit_LittleFS_File.h and InternalFileSystem.h.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>