### PR TITLE
nrf52(fs): add File() default constructor bound to InternalFS

### DIFF
--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp
@@ -24,6 +24,7 @@
 
 #include <Arduino.h>
 #include "Adafruit_LittleFS.h"
+#include "InternalFileSystem.h"
 #include "littlefs/lfs.h"
 
 //--------------------------------------------------------------------+
@@ -416,5 +417,12 @@ void File::rewindDirectory (void)
     lfs_dir_rewind(_fs->_getFS(), _dir);
   }
   _fs->_unlockFS();
+}
+
+// Default constructor — binds to the global InternalFS instance.
+// Allows File to be declared without an explicit filesystem argument,
+// matching the API of ESP32/RP2040/Portduino File objects.
+File::File() : File(InternalFS)
+{
 }
 

--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.h
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.h
@@ -43,6 +43,7 @@ class File : public Stream
   public:
     File (Adafruit_LittleFS &fs);
     File (char const *filename, uint8_t mode, Adafruit_LittleFS &fs);
+    File (); // default-constructs against InternalFS; defined in Adafruit_LittleFS_File.cpp
 
   public:
 


### PR DESCRIPTION
## Summary

- Adds a `File()` default constructor to `Adafruit_LittleFS_File` that delegates to `File(InternalFS)`
- Allows `File file;` declarations without an explicit filesystem argument, matching the API already available on ESP32, RP2040, and Portduino
- Implementation is in `.cpp` (not inline in the header) to avoid a circular include between `Adafruit_LittleFS_File.h` and `InternalFileSystem.h`

## Motivation

The Meshtastic firmware has a `#if defined(ARCH_NRF52) || defined(ARCH_STM32WL)` guard in `src/xmodem.h` (and other shared FS files) that constructs `File` objects as `File(FSCom)` rather than the idiomatic `File file;`. With this constructor in place, those guards can be removed and the shared code unified across all platforms.

This is a prerequisite for a Meshtastic firmware cleanup PR that removes ~18 arch-specific `#ifdef` guards from `FSCommon.cpp`, `SafeFile.cpp`, `NodeDB.cpp`, and `xmodem.h`.

## Changes

- `libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.h`: declare `File()` default constructor
- `libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp`: implement `File::File() : File(InternalFS) {}`; add `#include "InternalFileSystem.h"`

## Test plan

- [ ] Build `rak4631` (or any nRF52840 target) with a Meshtastic firmware that uses `File file;` in `xmodem.h` — should compile without errors
- [ ] Verify `File file;` default-initialises against `InternalFS` at runtime (xmodem send/receive flow)
- [ ] No regression on existing `File(fs)` or `File(filename, mode, fs)` constructor paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)