### PR TITLE
Allow build-flag override of loop/callback task stack sizes

### DIFF
--- a/cores/nRF5/main.cpp
+++ b/cores/nRF5/main.cpp
@@ -39,8 +39,15 @@ void Bluefruit_printInfo() {}
 void initVariant() __attribute__((weak));
 void initVariant() { }
 
+// Allow applications to override the task stack sizes via build flags
+// (e.g. -DLOOP_STACK_SZ=2048), mirroring CFG_BLE_TASK_STACKSIZE in the
+// Bluefruit library. Values are in WORDS (multiply by 4 for bytes).
+#ifndef LOOP_STACK_SZ
 #define LOOP_STACK_SZ       (256*4)
+#endif
+#ifndef CALLBACK_STACK_SZ
 #define CALLBACK_STACK_SZ   (256*3)
+#endif
 
 static TaskHandle_t  _loopHandle;
 


### PR DESCRIPTION
## Why

The Arduino `loop` task is created with a hard-coded 4 KB stack (`LOOP_STACK_SZ = 256*4` words) and the AdaCallback task with 3 KB. Neither can be overridden by an application.

On Meshtastic nRF52840 targets, the entire firmware (cooperative OSThread scheduler) runs on the loop task. An SWD fault capture (RAKDAP + pyocd `vector_catch=h`) during BLE first-sync showed the loop task's SP driven **40 bytes below its own `pxStack` base**, with the stack paint (`0xa5a5a5a5`) consumed to the floor — the overflow corrupts adjacent heap allocations (in the captured fault, a FreeRTOS semaphore handle was overwritten and subsequently dereferenced → BusFault → silent `NVIC_SystemReset`). This presents in the field as meshtastic/firmware devices resetting during phone pairing/first-sync.

## What

Wrap `LOOP_STACK_SZ` and `CALLBACK_STACK_SZ` in `#ifndef` so applications can size them via build flags (e.g. `-DLOOP_STACK_SZ=2048`), exactly like the Bluefruit library's `CFG_BLE_TASK_STACKSIZE`. **Default values are unchanged** — no behavior change for existing users.

Validated on hardware (Seeed T1000-E): with `-DLOOP_STACK_SZ=2048` the previously 100%-reproducible pairing crash is gone and the stack paint shows healthy margin under load. Companion firmware PR sets the flag for nRF52 targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing the stack sizes of the main loop task and callback task through build flags, while keeping the existing defaults unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->